### PR TITLE
Use os specific directory separator

### DIFF
--- a/code/mbtiles2compactcache.py
+++ b/code/mbtiles2compactcache.py
@@ -74,7 +74,7 @@ class Bundle:
         self.fd = None
         regex = r"L(..)"
         self.level = re.findall(regex, self.file_name)[0]
-        fname = self.file_name.split('.bundle')[0].split('\\')[-1]
+        fname = self.file_name.split('.bundle')[0].split(os.sep)[-1]
         s_val = fname[1:].split('C')
         self.row_offset = int(s_val[0], 16)
         self.col_offset = int(s_val[1], 16)


### PR DESCRIPTION
This script works only on windows OS, because it uses hard coded backslahes as directory separator.

The fix replaces the backshalsh with the python variable `os.sep`. Now it should run on all OS without exceptions.